### PR TITLE
Updates to man pages.

### DIFF
--- a/man/syscall/_exit.html
+++ b/man/syscall/_exit.html
@@ -49,7 +49,7 @@ Standard C Library (libc, -lc)
 <p>
 <tt>#include &lt;unistd.h&gt;</tt><br>
 <br>
-<tt>void,</tt><br>
+<tt>void</tt><br>
 <tt>_exit(int </tt><em>exitcode</em><tt>);</tt>
 </p>
 

--- a/man/syscall/close.html
+++ b/man/syscall/close.html
@@ -55,8 +55,8 @@ Standard C Library (libc, -lc)
 
 <h3>Description</h3>
 <p>
-The file handle <em>fd</em> is closed. The same file handle may then
-be returned again from <A HREF=open.html>open</A>,
+The file handle identified by file descriptor <em>fd</em> is closed. 
+The same file handle may then be returned again from <A HREF=open.html>open</A>,
 <A HREF=dup2.html>dup2</A>, <A HREF=pipe.html>pipe</A>, or similar
 calls.
 </p>
@@ -87,7 +87,7 @@ mentioned here.
 <table width=90%>
 <tr><td width=5% rowspan=10>&nbsp;</td>
     <td width=10%>EBADF</td>
-			<td><em>fd</em> is not a valid file handle.</td></tr>
+			<td><em>fd</em> is not a valid file descriptor.</td></tr>
 <tr><td>EIO</td>	<td>A hard I/O error occurred.</td></tr>
 </table>
 </p>

--- a/man/syscall/dup2.html
+++ b/man/syscall/dup2.html
@@ -55,9 +55,9 @@ Standard C Library (libc, -lc)
 
 <h3>Description</h3>
 <p>
-<tt>dup2</tt> clones the file handle <em>oldfd</em> onto the file
-handle <em>newfd</em>. If <em>newfd</em> names an already-open file,
-that file is closed.
+<tt>dup2</tt> clones the file handle identifed by file descriptor <em>oldfd</em> 
+onto the file handle identified by <em>newfd</em>. If <em>newfd</em> 
+names an already-open file, that file is closed.
 </p>
 
 <p>
@@ -74,8 +74,8 @@ dup2 is most commonly used to relocate opened files onto
 </p>
 
 <p>
-Both filehandles must be non-negative, and, if applicable, smaller
-than the maximum allowed file handle number.
+Both file descriptors must be non-negative, and, if applicable, 
+smaller than the maximum allowed file handle number.
 </p>
 
 <p>
@@ -116,9 +116,9 @@ here.
 <tr><td width=5% rowspan=3>&nbsp;</td>
     <td width=10% valign=top>EBADF</td>
 				<td><em>oldfd</em> is not a valid file
-				handle, or <em>newfd</em> is a value
+				descriptor, or <em>newfd</em> is a value
 				that cannot be a valid file
-				handle.</td></tr>
+				descriptor.</td></tr>
 <tr><td valign=top>EMFILE</td>	<td>The process's file table was full, or a
 				process-specific limit on open files
 				was reached.</td></tr>

--- a/man/syscall/fstat.html
+++ b/man/syscall/fstat.html
@@ -57,7 +57,7 @@ struct stat *</tt><em>statbuf</em><tt>);</tt>
 <h3>Description</h3>
 <p>
 <tt>fstat</tt> retrieves status information about the file referred to
-by the file handle <em>fd</em> and stores it in the stat structure
+by the file descriptor <em>fd</em> and stores it in the stat structure
 pointed to by <em>statbuf</em>.
 </p>
 

--- a/man/syscall/ftruncate.html
+++ b/man/syscall/ftruncate.html
@@ -87,8 +87,8 @@ mentioned here.
 <table width=90%>
 <tr><td width=5% rowspan=3>&nbsp;</td>
     <td width=10% valign=top>EBADF</td>
-				<td><em>fd</em> is not a valid file handle, or
-				it is not open for writing.</td></tr>
+				<td><em>fd</em> is not a valid file descriptor, 
+				or it is not open for writing.</td></tr>
 <tr><td valign=top>EIO</td>	<td>A hard I/O error occurred.</td></tr>
 <tr><td valign=top>EFAULT</td>	<td><em>buf</em> points to an invalid
 				address.</td></tr>

--- a/man/syscall/getdirentry.html
+++ b/man/syscall/getdirentry.html
@@ -57,7 +57,7 @@ size_t </tt><em>buflen</em><tt>);</tt>
 <h3>Description</h3>
 <p>
 <tt>getdirentry</tt> retrieves the next filename from a directory
-referred to by the file handle <em>filehandle</em>. The name is stored
+referred to by the file descriptor <em>fd</em>. The name is stored
 in <em>buf</em>, an area of size <em>buflen</em>. The length of of the
 name actually found is returned.
 </p>

--- a/man/syscall/ioctl.html
+++ b/man/syscall/ioctl.html
@@ -57,7 +57,7 @@ void *</tt><em>data</em><tt>);</tt>
 <h3>Description</h3>
 <p>
 <tt>ioctl</tt> performs an object-specific operation <em>code</em> on
-the object referred to by the file handle <em>fd</em>. The
+the object referred to by the file descriptor <em>fd</em>. The
 <em>data</em> argument may point to supplemental data required or
 returned by the operation. The size of buffer required, if any, and
 other such matters are operation-specific.

--- a/man/syscall/lseek.html
+++ b/man/syscall/lseek.html
@@ -57,8 +57,8 @@ int </tt><em>whence</em><tt>);</tt>
 <h3>Description</h3>
 <p>
 <tt>lseek</tt> alters the current seek position of the file handle
-<em>filehandle</em>, seeking to a new position based on <em>pos</em>
-and <em>whence</em>.
+identified by file descriptor <em>fd</em>, seeking to a new position 
+based on <em>pos</em> and <em>whence</em>.
 </p>
 
 <p>
@@ -122,7 +122,7 @@ mentioned here.
 <tr><td width=5% rowspan=4>&nbsp;</td>
     <td width=10% valign=top>EBADF</td>
 				<td><em>fd</em> is not a valid file
-				handle.</td></tr>
+				descriptor.</td></tr>
 <tr><td valign=top>ESPIPE</td>	<td><em>fd</em> refers to an object
 				which does not support seeking.</td></tr>
 <tr><td valign=top>EINVAL</td>	<td><em>whence</em> is invalid.</td></tr>

--- a/man/syscall/open.html
+++ b/man/syscall/open.html
@@ -99,12 +99,12 @@ course's assignments.)
 </p>
 
 <p>
-<tt>open</tt> returns a file handle suitable for passing to
+<tt>open</tt> returns a file descriptor suitable for passing to
 <A HREF=read.html>read</A>,
 <A HREF=write.html>write</A>,
 <A HREF=close.html>close</A>,
-etc. This file handle must be greater than or equal to zero.  Note
-that file handles 0 (STDIN_FILENO), 1 (STDOUT_FILENO), and 2
+etc. This file descriptor must be greater than or equal to zero.  Note
+that file descriptors 0 (STDIN_FILENO), 1 (STDOUT_FILENO), and 2
 (STDERR_FILENO) are used in special ways and are typically assumed by
 user-level code to always be open.
 </p>
@@ -128,9 +128,9 @@ contain <tt>..</tt> is usually not quite atomic.
 
 <h3>Return Values</h3>
 <p>
-On success, <tt>open</tt> returns a nonnegative file handle. On error,
--1 is returned, and <A HREF=errno.html>errno</A> is set according to
-the error encountered.
+On success, <tt>open</tt> returns a nonnegative file descriptor. On 
+error, -1 is returned, and <A HREF=errno.html>errno</A> is set 
+according to the error encountered.
 </p>
 
 <h3>Errors</h3>

--- a/man/syscall/write.html
+++ b/man/syscall/write.html
@@ -51,7 +51,7 @@ Standard C Library (libc, -lc)
 <br>
 <tt>ssize_t</tt><br>
 <tt>write(int </tt><em>fd</em><tt>, const void *</tt><em>buf</em><tt>,
-size_t </tt><em>nbytes</em><tt>);</tt>
+size_t </tt><em>buflen</em><tt>);</tt>
 </p>
 
 <h3>Description</h3>


### PR DESCRIPTION
This is Zachary Lebold from CSE 421. I hope you find that these changes are worthwhile. I found a bunch of references to file handles in the man pages that were actually talking about file descriptors. The _exit page had an extra "," floating around for no reason. And the size_t parameter of write was called "nbytes" but was later referred to as "buflen", which is consistent with read.
