### PR TITLE
Improved opentest

### DIFF
--- a/userland/testbin/opentest/opentest.c
+++ b/userland/testbin/opentest/opentest.c
@@ -66,11 +66,11 @@ main(int argc, char **argv)
 	if(fd1 < 0) {
 		err(-1, "Open syscall failed");
 	}
-	else if(fd1 < 3) {
-		warnx("Open syscall returned number used by standard file descriptors (0,1,2)");
-	}
-	else if(fd1 == fd) {
+  else if(fd1 == fd) {
 		err(-1, "Open syscall returned same file descriptor for second open() call\n");
+	}
+	else(fd1 < 3) {
+		warnx("Open syscall returned number used by standard file descriptors (0,1,2)");
 	}
 
 


### PR DESCRIPTION
The current version of opentest.c passes if opening bin/true twice returned the same file descriptor AND the file descriptor is either 0, 1 or 2 (it just warns the user that the number returned is used by standard file descriptors). This quick fix handles this edge case.